### PR TITLE
Enable CORS on WaitingQueue for AB14556.

### DIFF
--- a/Apps/WaitingQueueWeb/Program.cs
+++ b/Apps/WaitingQueueWeb/Program.cs
@@ -56,6 +56,8 @@ namespace BCGov.WaitingQueue
 
             builder.Services.AddSingleton<IConnectionMultiplexer>(_ => ConnectionMultiplexer.Connect(builder.Configuration.GetValue<string>("RedisConnection")));
 
+            builder.Services.AddCors(options => options.AddPolicy("allowAny", policy => policy.AllowAnyOrigin().AllowAnyMethod().AllowAnyHeader()));
+
             builder.Services.AddTransient<ITicketService, RedisTicketService>();
             builder.Services.AddTransient<IDateTimeDelegate, DateTimeDelegate>();
             builder.Services.AddTransient<IWebTicketDelegate, WebTicketDelegate>();
@@ -73,6 +75,20 @@ namespace BCGov.WaitingQueue
             }
 
             app.MapControllers();
+
+            // Enable CORS
+            string? enableCors = builder.Configuration.GetValue<string>("AllowOrigins");
+            if (!string.IsNullOrEmpty(enableCors))
+            {
+                app.UseCors(
+                    build =>
+                    {
+                        build
+                            .WithOrigins(enableCors)
+                            .AllowAnyHeader()
+                            .AllowAnyMethod();
+                    });
+            }
 
             app.Run();
         }

--- a/Apps/WaitingQueueWeb/appsettings.json
+++ b/Apps/WaitingQueueWeb/appsettings.json
@@ -5,6 +5,7 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
+  "AllowOrigins": "*",
   "AllowedHosts": "*",
   "RedisConnection": "SECRET"
 }


### PR DESCRIPTION
Enable CORS so that WaitingQueue endpoints can be accessed from HealthGateway.

<img width="1164" alt="Screenshot 2022-12-15 at 3 48 48 PM" src="https://user-images.githubusercontent.com/58790456/207990687-6c6c4922-4eaf-4ec1-8719-9c179522d3c8.png">
