### PR TITLE
Remove string interpolation placeholder value for AB#14559.

### DIFF
--- a/Apps/TicketManagement/Validation/TicketRequest.cs
+++ b/Apps/TicketManagement/Validation/TicketRequest.cs
@@ -34,7 +34,7 @@ namespace BCGov.WaitingQueue.TicketManagement.Validation
             {
                 // Not found
                 throw new ProblemDetailsException(ExceptionUtility.CreateProblemDetails(
-                    "The requested room: {room} was not found.",
+                    "The requested room was not found.",
                     HttpStatusCode.NotFound,
                     nameof(TicketRequest)));
             }


### PR DESCRIPTION
Removed no longer required string interpolation placeholder value in TicketRequest.ValidateRoomConfig method.

<img width="1632" alt="Screenshot 2022-12-16 at 12 12 27 AM" src="https://user-images.githubusercontent.com/58790456/208053902-6eafa599-0393-4e56-9152-61e0a630ac9f.png">
