### PR TITLE
Use dot net 7 problem details instead of Hellang Middleware for AB#14579

### DIFF
--- a/Apps/WaitingQueueWeb/Configuration/ControllerConfiguration.cs
+++ b/Apps/WaitingQueueWeb/Configuration/ControllerConfiguration.cs
@@ -1,0 +1,40 @@
+// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace BCGov.WaitingQueue.Configuration
+{
+    using System.Diagnostics.CodeAnalysis;
+    using Microsoft.AspNetCore.Builder;
+    using Microsoft.Extensions.DependencyInjection;
+
+    /// <summary>
+    /// Provides ASP.Net Services related to controllers.
+    /// </summary>
+    [ExcludeFromCodeCoverage]
+    public static class ControllerConfiguration
+    {
+        /// <summary>
+        /// Adds and configures the controllers.
+        /// </summary>
+        /// <param name="builder">The web application builder to use.</param>
+        public static void ConfigureControllers(WebApplicationBuilder builder)
+        {
+            builder.Services.AddControllers(options =>
+            {
+                options.Filters.Add<HttpResponseExceptionFilter>();
+            });
+        }
+    }
+}

--- a/Apps/WaitingQueueWeb/Configuration/CorsConfiguration.cs
+++ b/Apps/WaitingQueueWeb/Configuration/CorsConfiguration.cs
@@ -1,0 +1,60 @@
+// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace BCGov.WaitingQueue.Configuration
+{
+    using System.Diagnostics.CodeAnalysis;
+    using Microsoft.AspNetCore.Builder;
+    using Microsoft.Extensions.Configuration;
+    using Microsoft.Extensions.DependencyInjection;
+
+    /// <summary>
+    /// Provides ASP.Net Services related to cors.
+    /// </summary>
+    [ExcludeFromCodeCoverage]
+    public static class CorsConfiguration
+    {
+        /// <summary>
+        /// Adds and configures the services required to use cors.
+        /// </summary>
+        /// <param name="services">The service collection to add forward proxies into.</param>
+        public static void ConfigureCors(IServiceCollection services)
+        {
+            services.AddCors(options => options.AddPolicy("allowAny", policy => policy.AllowAnyOrigin().AllowAnyMethod().AllowAnyHeader()));
+        }
+
+        /// <summary>
+        /// Configures the app to use cors.
+        /// </summary>
+        /// <param name="builder">The web application builder to use.</param>
+        /// <param name="app">The application to use.</param>
+        public static void UseCors(WebApplicationBuilder builder, IApplicationBuilder app)
+        {
+            // Enable CORS
+            string? enableCors = builder.Configuration.GetValue<string>("AllowOrigins");
+            if (!string.IsNullOrEmpty(enableCors))
+            {
+                app.UseCors(
+                    build =>
+                    {
+                        build
+                            .WithOrigins(enableCors)
+                            .AllowAnyHeader()
+                            .AllowAnyMethod();
+                    });
+            }
+        }
+    }
+}

--- a/Apps/WaitingQueueWeb/Configuration/ExceptionHandlingConfiguration.cs
+++ b/Apps/WaitingQueueWeb/Configuration/ExceptionHandlingConfiguration.cs
@@ -13,23 +13,21 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 // -------------------------------------------------------------------------
-namespace BCGov.WaitingQueue
+namespace BCGov.WaitingQueue.Configuration
 {
     using System.Diagnostics.CodeAnalysis;
-    using System.Net;
-    using Hellang.Middleware.ProblemDetails;
     using Microsoft.AspNetCore.Builder;
+    using Microsoft.AspNetCore.Diagnostics;
     using Microsoft.AspNetCore.Hosting;
-    using Microsoft.AspNetCore.Mvc;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Hosting;
     using ProblemDetailsException = BCGov.WaitingQueue.TicketManagement.ErrorHandling.ProblemDetailsException;
 
     /// <summary>
-    /// Provides ASP.Net Services related to Problem Details.
+    /// Provides ASP.Net Services related to exception handling.
     /// </summary>
     [ExcludeFromCodeCoverage]
-    public static class ProblemDetailsConfiguration
+    public static class ExceptionHandlingConfiguration
     {
         /// <summary>
         /// Adds and configures the services required to use problem details.
@@ -38,30 +36,23 @@ namespace BCGov.WaitingQueue
         /// <param name="environment">The environment the services are associated with.</param>
         public static void ConfigureProblemDetails(IServiceCollection services, IWebHostEnvironment environment)
         {
-            services.AddProblemDetails(
-                setup =>
-                {
-                    setup.IncludeExceptionDetails = (_, _) => environment.IsDevelopment();
-
-                    setup.Map<ProblemDetailsException>(
-                        exception => new ProblemDetails
-                        {
-                            Title = exception.ProblemDetails?.Title,
-                            Detail = exception.ProblemDetails?.Detail,
-                            Status = (int)(exception.ProblemDetails?.StatusCode ?? HttpStatusCode.InternalServerError),
-                            Type = exception.ProblemDetails?.ProblemType,
-                            Instance = exception.ProblemDetails?.Instance,
-                        });
-                });
+            services.AddProblemDetails();
         }
 
         /// <summary>
         /// Configures the app to use problem details middleware.
         /// </summary>
-        /// <param name="app">The application builder where modules are specified to be used.</param>
-        public static void UseProblemDetails(IApplicationBuilder app)
+        /// <param name="app">The application builder to use.</param>
+        /// <param name="environment">The environment to use.</param>
+        public static void UseProblemDetails(IApplicationBuilder app, IWebHostEnvironment environment)
         {
-            app.UseProblemDetails();
+            app.UseExceptionHandler();
+            app.UseStatusCodePages();
+
+            if (environment.IsDevelopment())
+            {
+                app.UseDeveloperExceptionPage();
+            }
         }
     }
 }

--- a/Apps/WaitingQueueWeb/Configuration/HttpResponseExceptionFilter.cs
+++ b/Apps/WaitingQueueWeb/Configuration/HttpResponseExceptionFilter.cs
@@ -1,0 +1,53 @@
+// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace BCGov.WaitingQueue.Configuration
+{
+    using BCGov.WaitingQueue.TicketManagement.ErrorHandling;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.AspNetCore.Mvc.Filters;
+
+    /// <summary>
+    /// Action filter to modify the contents of a response outside of the controller
+    /// using a custom exception.
+    /// </summary>
+    public class HttpResponseExceptionFilter : IActionFilter, IOrderedFilter
+    {
+        /// <summary>
+        /// Gets an Order of the maximum integer value minus 10.
+        /// This Order allows other filters to run at the end of the pipeline..
+        /// </summary>
+        public int Order => int.MaxValue - 10;
+
+        /// <inheritdoc />
+        public void OnActionExecuting(ActionExecutingContext context)
+        {
+            // Method intentionally left empty.
+        }
+
+        /// <inheritdoc />
+        public void OnActionExecuted(ActionExecutedContext context)
+        {
+            if (context.Exception is ProblemDetailsException problemDetailsException)
+            {
+                context.Result = new ObjectResult(problemDetailsException.ProblemDetails)
+                {
+                    StatusCode = (int)problemDetailsException.ProblemDetails!.StatusCode,
+                };
+                context.ExceptionHandled = true;
+            }
+        }
+    }
+}

--- a/Apps/WaitingQueueWeb/Configuration/RedisConfiguration.cs
+++ b/Apps/WaitingQueueWeb/Configuration/RedisConfiguration.cs
@@ -1,0 +1,39 @@
+// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace BCGov.WaitingQueue.Configuration
+{
+    using System.Diagnostics.CodeAnalysis;
+    using Microsoft.AspNetCore.Builder;
+    using Microsoft.Extensions.Configuration;
+    using Microsoft.Extensions.DependencyInjection;
+    using StackExchange.Redis;
+
+    /// <summary>
+    /// Provides ASP.Net Services related to redis.
+    /// </summary>
+    [ExcludeFromCodeCoverage]
+    public static class RedisConfiguration
+    {
+        /// <summary>
+        /// Adds and configures redis.
+        /// </summary>
+        /// <param name="builder">The web application builder to use.</param>
+        public static void ConfigureRedis(WebApplicationBuilder builder)
+        {
+            builder.Services.AddSingleton<IConnectionMultiplexer>(_ => ConnectionMultiplexer.Connect(builder.Configuration.GetValue<string>("RedisConnection")));
+        }
+    }
+}

--- a/Apps/WaitingQueueWeb/Configuration/ServiceConfiguration.cs
+++ b/Apps/WaitingQueueWeb/Configuration/ServiceConfiguration.cs
@@ -1,0 +1,42 @@
+// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace BCGov.WaitingQueue.Configuration
+{
+    using System.Diagnostics.CodeAnalysis;
+    using BCGov.WaitingQueue.Common.Delegates;
+    using BCGov.WaitingQueue.TicketManagement.Services;
+    using BCGov.WebCommon.Delegates;
+    using Microsoft.AspNetCore.Builder;
+    using Microsoft.Extensions.DependencyInjection;
+
+    /// <summary>
+    /// Provides ASP.Net Services related to controllers.
+    /// </summary>
+    [ExcludeFromCodeCoverage]
+    public static class ServiceConfiguration
+    {
+        /// <summary>
+        /// Adds and configures services.
+        /// </summary>
+        /// <param name="builder">The web application builder to use.</param>
+        public static void ConfigureServices(WebApplicationBuilder builder)
+        {
+            builder.Services.AddTransient<ITicketService, RedisTicketService>();
+            builder.Services.AddTransient<IDateTimeDelegate, DateTimeDelegate>();
+            builder.Services.AddTransient<IWebTicketDelegate, WebTicketDelegate>();
+        }
+    }
+}

--- a/Apps/WaitingQueueWeb/Configuration/SwaggerConfiguration.cs
+++ b/Apps/WaitingQueueWeb/Configuration/SwaggerConfiguration.cs
@@ -1,0 +1,61 @@
+// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace BCGov.WaitingQueue.Configuration
+{
+    using System;
+    using System.Diagnostics.CodeAnalysis;
+    using System.IO;
+    using System.Reflection;
+    using Microsoft.AspNetCore.Builder;
+    using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.Hosting;
+
+    /// <summary>
+    /// Provides ASP.Net Services related to swagger.
+    /// </summary>
+    [ExcludeFromCodeCoverage]
+    public static class SwaggerConfiguration
+    {
+        /// <summary>
+        /// Adds and configures swagger.
+        /// </summary>
+        /// <param name="builder">The web application builder to use.</param>
+        public static void ConfigureSwagger(WebApplicationBuilder builder)
+        {
+            // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
+            builder.Services.AddEndpointsApiExplorer();
+
+            builder.Services.AddSwaggerGen(options =>
+            {
+                var xmlFilename = $"{Assembly.GetExecutingAssembly().GetName().Name}.xml";
+                options.IncludeXmlComments(Path.Combine(AppContext.BaseDirectory, xmlFilename));
+            });
+        }
+
+        /// <summary>
+        /// Configures the app to use swagger.
+        /// </summary>
+        /// <param name="app">The web application to use.</param>
+        public static void UseSwagger(WebApplication app)
+        {
+            if (app.Environment.IsDevelopment())
+            {
+                app.UseSwagger();
+                app.UseSwaggerUI();
+            }
+        }
+    }
+}

--- a/Apps/WaitingQueueWeb/WaitingQueueWeb.csproj
+++ b/Apps/WaitingQueueWeb/WaitingQueueWeb.csproj
@@ -8,7 +8,6 @@
 
     <PropertyGroup Condition=" '$(RunConfiguration)' == 'WaitingQueue' " />
     <ItemGroup>
-        <PackageReference Include="Hellang.Middleware.ProblemDetails" Version="6.5.1" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
         <PackageReference Update="Microsoft.CodeAnalysis" Version="4.4.0" />
     </ItemGroup>


### PR DESCRIPTION
Replace existing Hellang Middleware Problem Details with dot net 7 out of box Problem Details.

- Removed nugget package for Hellang Middleware Problem Details
- Update Problem Detail implementation based on dot net 7
- Created static configuration files to reduce namespace imports in Program

**Processed:**

<img width="1946" alt="Screenshot 2022-12-19 at 9 34 21 PM" src="https://user-images.githubusercontent.com/58790456/208593083-1af0bd6f-8161-4ddd-84f8-9ca847eb9609.png">

**Queued:**

<img width="2068" alt="Screenshot 2022-12-19 at 9 34 31 PM" src="https://user-images.githubusercontent.com/58790456/208593076-8a7b3b75-75fd-4e45-9fad-cb5bdb173deb.png">


**Custom Exception:**

<img width="1972" alt="Screenshot 2022-12-19 at 9 34 52 PM" src="https://user-images.githubusercontent.com/58790456/208593047-89926779-d719-4d8a-93d8-3d1f8f543f8a.png">

**Uncaught Exception:**

<img width="2019" alt="Screenshot 2022-12-19 at 9 37 58 PM" src="https://user-images.githubusercontent.com/58790456/208592996-279cf138-4d2a-4eec-a6cf-e8278be951de.png">
