### PR TITLE
Enable Admin UI and Auth

### DIFF
--- a/Apps/.editorconfig
+++ b/Apps/.editorconfig
@@ -299,7 +299,7 @@ dotnet_diagnostic.ca2000.severity = warning
 dotnet_diagnostic.ca2002.severity = warning
 
 # CA2007: Consider calling ConfigureAwait on the awaited task
-dotnet_diagnostic.ca2007.severity = warning
+dotnet_diagnostic.ca2007.severity = none
 
 # CA2008: Do not create tasks without passing a TaskScheduler
 dotnet_diagnostic.ca2008.severity = warning

--- a/Apps/Admin/Client/Admin.Client.csproj
+++ b/Apps/Admin/Client/Admin.Client.csproj
@@ -41,7 +41,6 @@
     </ItemGroup>
 
     <ItemGroup>
-        <Folder Include="Api\" />
         <Folder Include="Models\" />
         <Folder Include="wwwroot\fonts\" />
         <Folder Include="Authorization\" />

--- a/Apps/Admin/Client/Api/IRoomApi.cs
+++ b/Apps/Admin/Client/Api/IRoomApi.cs
@@ -1,0 +1,43 @@
+// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace BCGov.WaitingQueue.Admin.Client.Api
+{
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using BCGov.WaitingQueue.Admin.Common.Models;
+    using Refit;
+
+    /// <summary>
+    /// API to interact with the Room configuration.
+    /// </summary>
+    public interface IRoomApi
+    {
+        /// <summary>
+        /// Returns key/value pairing of room name and room configuration.
+        /// </summary>
+        /// <returns>The list of room configs.</returns>
+        [Get("/")]
+        Task<IDictionary<string, RoomConfiguration>> GetRoomsAsync();
+
+        /// <summary>
+        /// Creates or updates the room configuration.
+        /// </summary>
+        /// <param name="roomConfig">The room to create or update.</param>
+        /// <returns>The newly created or updated room configuration.</returns>
+        [Put("/")]
+        Task<RoomConfiguration> UpsertConfiguration(RoomConfiguration roomConfig);
+    }
+}

--- a/Apps/Admin/Client/Authorization/Roles.cs
+++ b/Apps/Admin/Client/Authorization/Roles.cs
@@ -24,5 +24,10 @@ namespace BCGov.WaitingQueue.Admin.Client.Authorization
         /// Represents an overall Admin User (super).
         /// </summary>
         public const string Admin = "AdminUser";
+
+        /// <summary>
+        /// Represents a user that is able to view statistics.
+        /// </summary>
+        public const string Stats = "StatsUser";
     }
 }

--- a/Apps/Admin/Client/Authorization/RolesClaimsPrincipalFactory.cs
+++ b/Apps/Admin/Client/Authorization/RolesClaimsPrincipalFactory.cs
@@ -42,7 +42,7 @@ namespace BCGov.WaitingQueue.Admin.Client.Authorization
             RemoteUserAccount account,
             RemoteAuthenticationUserOptions options)
         {
-            ClaimsPrincipal? user = await base.CreateUserAsync(account, options).ConfigureAwait(true);
+            ClaimsPrincipal? user = await base.CreateUserAsync(account, options);
             if (user.Identity == null || !user.Identity.IsAuthenticated)
             {
                 return user;

--- a/Apps/Admin/Client/Components/RoomConfiguration/RoomConfigurationDialog.razor
+++ b/Apps/Admin/Client/Components/RoomConfiguration/RoomConfigurationDialog.razor
@@ -3,10 +3,10 @@
         <MudForm @ref="Form">
             <MudGrid Spacing="0">
                 <MudItem xs="6">
-                    <WqaTextField Label="Name" @bind-Value="RoomConfiguration.Id" T="@string" Required="@true" RightMargin="@Breakpoint.Always" />
+                    <WqaTextField Label="Name" @bind-Value="RoomConfiguration.Name" T="@string" Required="@true" RightMargin="@Breakpoint.Always" />
                 </MudItem>
                 <MudItem xs="6">
-                    <WqaTextField Label="Description" @bind-Value="RoomConfiguration.Name" T="@string" Required="@true" RightMargin="@Breakpoint.Always" />
+                    &nbsp;
                 </MudItem>
                 <MudItem xs="6">
                     <WqaTextField Label="Check In Frequency" @bind-Value="RoomConfiguration.CheckInFrequency" T="@int" Required="@true" RightMargin="@Breakpoint.Always" />

--- a/Apps/Admin/Client/Components/RoomConfiguration/RoomConfigurationDialog.razor.cs
+++ b/Apps/Admin/Client/Components/RoomConfiguration/RoomConfigurationDialog.razor.cs
@@ -16,26 +16,26 @@
 
 namespace BCGov.WaitingQueue.Admin.Client.Components.RoomConfiguration;
 
+using System.Threading.Tasks;
 using BCGov.WaitingQueue.Admin.Common.Models;
 using Microsoft.AspNetCore.Components;
 using MudBlazor;
-using System.Threading.Tasks;
 
 /// <summary>
 /// Show dialog to add/edit room configuration.
 /// </summary>
 public partial class RoomConfigurationDialog
 {
+    /// <summary>
+    /// Gets or sets the room configuration instance to edit.
+    /// </summary>
+    [Parameter]
+    public RoomConfiguration RoomConfiguration { get; set; } = new();
+
     [CascadingParameter]
     private MudDialogInstance MudDialog { get; set; } = default!;
 
     private MudForm Form { get; set; } = default!;
-
-    /// <summary>
-    /// Gets or set the room configuration instance to edit
-    /// </summary>
-    [Parameter]
-    public RoomConfiguration RoomConfiguration { get; set; } = new RoomConfiguration();
 
     private async Task HandleClickCancelAsync()
     {

--- a/Apps/Admin/Client/Components/Site/InactivityDialog.razor.cs
+++ b/Apps/Admin/Client/Components/Site/InactivityDialog.razor.cs
@@ -38,7 +38,7 @@ namespace BCGov.WaitingQueue.Admin.Client.Components.Site
         /// <inheritdoc/>
         protected override async Task OnInitializedAsync()
         {
-            await base.OnInitializedAsync().ConfigureAwait(true);
+            await base.OnInitializedAsync();
             this.timer.Elapsed += this.CountdownTimerTick;
             this.timer.AutoReset = true;
             this.timer.Start();

--- a/Apps/Admin/Client/Components/Site/NavMenu.razor
+++ b/Apps/Admin/Client/Components/Site/NavMenu.razor
@@ -2,10 +2,10 @@
 
 <MudNavMenu>
     <AuthorizeView Roles="@($"{Roles.Admin}")">
-        <MudNavLink Href="room-config" Icon="fas fa-glass-water">Rooms</MudNavLink>
+        <MudNavLink Href="room-config" Icon="fas fa-screwdriver-wrench">Room Config</MudNavLink>
     </AuthorizeView>
-    <AuthorizeView Roles="@($"{Roles.Admin}")">
-        <MudNavLink Href="admin" Icon="fas fa-screwdriver-wrench">Administration</MudNavLink>
+    <AuthorizeView Roles="@($"{Roles.Admin}, {Roles.Stats}")">
+        <MudNavLink Href="stats" Icon="fas fa-chart-bar">Statistics</MudNavLink>
     </AuthorizeView>
     <MudSpacer />
     <MudSpacer />

--- a/Apps/Admin/Client/Components/Site/NavigationConfirmation.razor.cs
+++ b/Apps/Admin/Client/Components/Site/NavigationConfirmation.razor.cs
@@ -44,7 +44,7 @@ public partial class NavigationConfirmation : FluxorComponent
     {
         bool navigationConfirmed = await this.JsRuntime
             .InvokeAsync<bool>("confirm", "Leave page? Changes you made may not be saved.")
-            .ConfigureAwait(true);
+            ;
 
         if (!navigationConfirmed)
         {

--- a/Apps/Admin/Client/Layouts/DefaultLayout.razor.cs
+++ b/Apps/Admin/Client/Layouts/DefaultLayout.razor.cs
@@ -48,9 +48,9 @@ namespace BCGov.WaitingQueue.Admin.Client.Layouts
         {
             this.Dispatcher.Dispatch(new ConfigurationActions.LoadAction());
 
-            if (await this.LocalStorage.ContainKeyAsync(DarkThemeKey).ConfigureAwait(true))
+            if (await this.LocalStorage.ContainKeyAsync(DarkThemeKey))
             {
-                this.DarkMode = await this.LocalStorage.GetItemAsync<bool>(DarkThemeKey).ConfigureAwait(true);
+                this.DarkMode = await this.LocalStorage.GetItemAsync<bool>(DarkThemeKey);
                 this.StateHasChanged();
             }
         }

--- a/Apps/Admin/Client/Layouts/MainLayout.razor.cs
+++ b/Apps/Admin/Client/Layouts/MainLayout.razor.cs
@@ -104,18 +104,18 @@ namespace BCGov.WaitingQueue.Admin.Client.Layouts
                 return;
             }
 
-            bool isAuthenticated = await this.IsAuthenticatedAsync().ConfigureAwait(true);
+            bool isAuthenticated = await this.IsAuthenticatedAsync();
             if (!isAuthenticated)
             {
                 return;
             }
 
-            IDialogReference dialog = await this.Dialog.ShowAsync<InactivityDialog>().ConfigureAwait(true);
+            IDialogReference dialog = await this.Dialog.ShowAsync<InactivityDialog>();
             this.IsInactivityModalShown = true;
 
-            DialogResult result = await dialog.Result.ConfigureAwait(true);
+            DialogResult result = await dialog.Result;
             bool activityDetected = result.Data as bool? == true;
-            await this.HandleInactivityAsync(activityDetected).ConfigureAwait(true);
+            await this.HandleInactivityAsync(activityDetected);
             this.IsInactivityModalShown = false;
         }
 
@@ -144,17 +144,17 @@ namespace BCGov.WaitingQueue.Admin.Client.Layouts
         /// <inheritdoc/>
         protected override async Task OnInitializedAsync()
         {
-            await base.OnInitializedAsync().ConfigureAwait(true);
+            await base.OnInitializedAsync();
 
-            if (await this.LocalStorage.ContainKeyAsync(DarkThemeKey).ConfigureAwait(true))
+            if (await this.LocalStorage.ContainKeyAsync(DarkThemeKey))
             {
-                this.DarkMode = await this.LocalStorage.GetItemAsync<bool>(DarkThemeKey).ConfigureAwait(true);
+                this.DarkMode = await this.LocalStorage.GetItemAsync<bool>(DarkThemeKey);
                 this.StateHasChanged();
             }
 
             this.TokenRefreshInterval = this.Configuration.GetValue("TokenRefreshInterval", 0);
             this.objectReference = DotNetObjectReference.Create(this);
-            await this.JsRuntime.InitializeInactivityTimer(this.objectReference).ConfigureAwait(true);
+            await this.JsRuntime.InitializeInactivityTimer(this.objectReference);
             this.tokenRefreshTimer.Elapsed += this.HandleTokenRefreshAsync;
             this.tokenRefreshTimer.Interval = this.TokenRefreshInterval;
             this.tokenRefreshTimer.AutoReset = true;
@@ -163,7 +163,7 @@ namespace BCGov.WaitingQueue.Admin.Client.Layouts
 
         private async Task<bool> IsAuthenticatedAsync()
         {
-            AuthenticationState authState = await this.AuthenticationStateProvider.GetAuthenticationStateAsync().ConfigureAwait(true);
+            AuthenticationState authState = await this.AuthenticationStateProvider.GetAuthenticationStateAsync();
             return authState.User.Identity?.IsAuthenticated == true;
         }
 
@@ -177,7 +177,7 @@ namespace BCGov.WaitingQueue.Admin.Client.Layouts
             }
 
             // try to refresh token
-            AccessTokenResult? tokenResult = await this.AccessTokenProvider.RequestAccessToken().ConfigureAwait(true);
+            AccessTokenResult? tokenResult = await this.AccessTokenProvider.RequestAccessToken();
             if (tokenResult.TryGetToken(out _))
             {
                 return;
@@ -190,7 +190,7 @@ namespace BCGov.WaitingQueue.Admin.Client.Layouts
         private async void HandleTokenRefreshAsync(object? sender, ElapsedEventArgs e)
         {
             // try to refresh token
-            AccessTokenResult? tokenResult = await this.AccessTokenProvider.RequestAccessToken().ConfigureAwait(true);
+            AccessTokenResult? tokenResult = await this.AccessTokenProvider.RequestAccessToken();
             if (tokenResult.TryGetToken(out _))
             {
                 return;
@@ -203,7 +203,7 @@ namespace BCGov.WaitingQueue.Admin.Client.Layouts
         private async Task ToggleTheme()
         {
             this.DarkMode = !this.DarkMode;
-            await this.LocalStorage.SetItemAsync(DarkThemeKey, this.DarkMode).ConfigureAwait(true);
+            await this.LocalStorage.SetItemAsync(DarkThemeKey, this.DarkMode);
         }
 
         private void DrawerToggle()

--- a/Apps/Admin/Client/Pages/AdminPage.razor
+++ b/Apps/Admin/Client/Pages/AdminPage.razor
@@ -1,7 +1,0 @@
-@page "/admin"
-@attribute [Authorize(Roles=Roles.Admin)]
-@layout MainLayout
-
-<WqaPageHeading>Administrator</WqaPageHeading>
-
-Nothing to see

--- a/Apps/Admin/Client/Pages/AuthenticationPage.razor.cs
+++ b/Apps/Admin/Client/Pages/AuthenticationPage.razor.cs
@@ -45,7 +45,7 @@ public partial class AuthenticationPage : ComponentBase
     /// <inheritdoc/>
     protected override async Task OnParametersSetAsync()
     {
-        AuthenticationState authState = await this.AuthenticationStateProvider.GetAuthenticationStateAsync().ConfigureAwait(true);
+        AuthenticationState authState = await this.AuthenticationStateProvider.GetAuthenticationStateAsync();
         if (this.Action == "logout-callback" && authState.User.Identity is { IsAuthenticated: true })
         {
             string loginPath = this.OptionsSnapshot.Get(Options.DefaultName).AuthenticationPaths.LogInPath;

--- a/Apps/Admin/Client/Pages/IndexPage.razor
+++ b/Apps/Admin/Client/Pages/IndexPage.razor
@@ -1,5 +1,5 @@
 @page "/"
-@attribute [Authorize]
+@attribute [Authorize(Roles = $"{Roles.Admin}, {Roles.Stats}")]
 
 <p class="text-center">
     Determining Default User Route

--- a/Apps/Admin/Client/Pages/IndexPage.razor.cs
+++ b/Apps/Admin/Client/Pages/IndexPage.razor.cs
@@ -35,9 +35,16 @@ namespace BCGov.WaitingQueue.Admin.Client.Pages
         /// <inheritdoc/>
         protected override async Task OnInitializedAsync()
         {
-            AuthenticationState authState = await this.AuthenticationStateProvider.GetAuthenticationStateAsync().ConfigureAwait(true);
+            AuthenticationState authState = await this.AuthenticationStateProvider.GetAuthenticationStateAsync();
             ClaimsPrincipal user = authState.User;
-            this.Navigation.NavigateTo("room-config", replace: true);
+            if (user.IsInRole(Roles.Admin))
+            {
+                this.Navigation.NavigateTo("room-config", replace: true);
+            }
+            else
+            {
+                this.Navigation.NavigateTo("stats", replace: true);
+            }
         }
     }
 }

--- a/Apps/Admin/Client/Pages/LoginPage.razor.cs
+++ b/Apps/Admin/Client/Pages/LoginPage.razor.cs
@@ -49,7 +49,7 @@ public partial class LoginPage : ComponentBase
     /// <inheritdoc/>
     protected override async Task OnInitializedAsync()
     {
-        AuthenticationState authState = await this.AuthenticationStateProvider.GetAuthenticationStateAsync().ConfigureAwait(true);
+        AuthenticationState authState = await this.AuthenticationStateProvider.GetAuthenticationStateAsync();
         if (authState.User.Identity is { IsAuthenticated: true })
         {
             this.NavigationManager.NavigateTo(this.ReturnPath ?? "/", replace: true);

--- a/Apps/Admin/Client/Pages/RoomConfigPage.razor
+++ b/Apps/Admin/Client/Pages/RoomConfigPage.razor
@@ -1,11 +1,16 @@
 @page "/room-config"
-@attribute [Authorize]
+@using BCGov.WaitingQueue.Admin.Common.Models
+@attribute [Authorize(Roles = $"{Roles.Admin}")]
 @layout MainLayout
 
 <WqaPageHeading>Room Configuration</WqaPageHeading>
+@if(!string.IsNullOrEmpty(ErrorMessage))
+{
+    <MudAlert Severity="Severity.Error" ShowCloseIcon="true" CloseIconClicked="@HandleCloseError" Class="my-2">@ErrorMessage</MudAlert>
+}
 <WqaButton OnClick="@HandleClickNewAsync">New</WqaButton>
 <MudList>
-    @foreach (var room in Rooms)
+    @foreach (RoomConfiguration room in Rooms.Values)
     {
         <MudListItem>
             <MudCard>

--- a/Apps/Admin/Client/Pages/StatisticsPage.razor
+++ b/Apps/Admin/Client/Pages/StatisticsPage.razor
@@ -1,0 +1,7 @@
+@page "/stats"
+@attribute [Authorize(Roles=$"{Roles.Admin}, {Roles.Stats}")]
+@layout MainLayout
+
+<WqaPageHeading>Statistics</WqaPageHeading>
+
+Nothing to see yet

--- a/Apps/Admin/Client/Pages/StatisticsPage.razor.cs
+++ b/Apps/Admin/Client/Pages/StatisticsPage.razor.cs
@@ -24,7 +24,7 @@ namespace BCGov.WaitingQueue.Admin.Client.Pages
     /// <summary>
     /// Backing logic for the Asdmin page.
     /// </summary>
-    public partial class AdminPage : ComponentBase
+    public partial class StatisticsPage : ComponentBase
     {
         [Inject]
         private NavigationManager Navigation { get; set; } = default!;
@@ -35,7 +35,7 @@ namespace BCGov.WaitingQueue.Admin.Client.Pages
         /// <inheritdoc/>
         protected override async Task OnInitializedAsync()
         {
-            AuthenticationState authState = await this.AuthenticationStateProvider.GetAuthenticationStateAsync().ConfigureAwait(true);
+            AuthenticationState authState = await this.AuthenticationStateProvider.GetAuthenticationStateAsync();
             ClaimsPrincipal user = authState.User;
 
             // if (user.IsInRole(Roles.Admin))

--- a/Apps/Admin/Client/Pages/UnauthorizedPage.razor.cs
+++ b/Apps/Admin/Client/Pages/UnauthorizedPage.razor.cs
@@ -35,7 +35,7 @@ public partial class UnauthorizedPage : ComponentBase
     /// <inheritdoc/>
     protected override async Task OnInitializedAsync()
     {
-        AuthenticationState authState = await this.AuthenticationStateProvider.GetAuthenticationStateAsync().ConfigureAwait(true);
+        AuthenticationState authState = await this.AuthenticationStateProvider.GetAuthenticationStateAsync();
         if (authState.User.Identity is not { IsAuthenticated: true })
         {
             this.NavigationManager.NavigateTo("/login", replace: true);

--- a/Apps/Admin/Client/Pages/UserInfoPage.razor.cs
+++ b/Apps/Admin/Client/Pages/UserInfoPage.razor.cs
@@ -54,8 +54,8 @@ namespace BCGov.WaitingQueue.Admin.Client.Pages
         /// <inheritdoc/>
         protected override async Task OnInitializedAsync()
         {
-            await this.GetClaimsPrincipalData().ConfigureAwait(true);
-            await this.CreateCookie("HGAdmin", "dark mode", 365).ConfigureAwait(true);
+            await this.GetClaimsPrincipalData();
+            await this.CreateCookie("HGAdmin", "dark mode", 365);
         }
 
         private async Task CreateCookie(string name, string value, int days)
@@ -72,17 +72,17 @@ namespace BCGov.WaitingQueue.Admin.Client.Pages
             }
 
             string cookieValue = $"{name}={value}{expires}; path=/";
-            await this.JsRuntime.InvokeVoidAsync("eval", $@"document.cookie = ""{cookieValue}""").ConfigureAwait(true);
+            await this.JsRuntime.InvokeVoidAsync("eval", $@"document.cookie = ""{cookieValue}""");
         }
 
         private async Task GetClaimsPrincipalData()
         {
-            AuthenticationState authState = await this.AuthenticationStateProvider.GetAuthenticationStateAsync().ConfigureAwait(true);
+            AuthenticationState authState = await this.AuthenticationStateProvider.GetAuthenticationStateAsync();
             ClaimsPrincipal user = authState.User;
 
             if (user.Identity != null && user.Identity.IsAuthenticated)
             {
-                AccessTokenResult? tokenResult = await this.TokenProvider.RequestAccessToken().ConfigureAwait(true);
+                AccessTokenResult? tokenResult = await this.TokenProvider.RequestAccessToken();
                 tokenResult.TryGetToken(out AccessToken? accessToken);
                 this.Token = accessToken.Value;
 

--- a/Apps/Admin/Client/Program.cs
+++ b/Apps/Admin/Client/Program.cs
@@ -97,12 +97,13 @@ namespace BCGov.WaitingQueue.Admin.Client
             builder.Services.AddBlazoredLocalStorage();
 
             app[0] = builder.Build();
-            await app[0].RunAsync().ConfigureAwait(true);
+            await app[0].RunAsync();
         }
 
         private static void RegisterRefitClients(this WebAssemblyHostBuilder builder)
         {
             RegisterRefitClient<IConfigurationApi>(builder, "api/Configuration", false);
+            RegisterRefitClient<IRoomApi>(builder, "api/Room", true);
         }
 
         private static void RegisterRefitClient<T>(WebAssemblyHostBuilder builder, string servicePath, bool isAuthorized)

--- a/Apps/Admin/Client/Store/Configuration/ConfigurationEffects.cs
+++ b/Apps/Admin/Client/Store/Configuration/ConfigurationEffects.cs
@@ -45,7 +45,7 @@ namespace BCGov.WaitingQueue.Admin.Client.Store.Configuration
 
             try
             {
-                ExternalConfiguration response = await this.ConfigApi.GetConfigurationAsync().ConfigureAwait(true);
+                ExternalConfiguration response = await this.ConfigApi.GetConfigurationAsync();
                 this.Logger.LogInformation("External configuration loaded successfully!");
                 dispatcher.Dispatch(new ConfigurationActions.LoadSuccessAction(response));
             }

--- a/Apps/Admin/Client/Utils/IJSRuntimeExtensionMethods.cs
+++ b/Apps/Admin/Client/Utils/IJSRuntimeExtensionMethods.cs
@@ -38,7 +38,7 @@ namespace BCGov.WaitingQueue.Admin.Client.Utils
         public static async ValueTask InitializeInactivityTimer<T>(this IJSRuntime js, DotNetObjectReference<T> dotNetObjectReference)
             where T : class
         {
-            await js.InvokeVoidAsync("initializeInactivityTimer", dotNetObjectReference).ConfigureAwait(true);
+            await js.InvokeVoidAsync("initializeInactivityTimer", dotNetObjectReference);
         }
     }
 }

--- a/Apps/Admin/Client/wwwroot/appsettings.Development.json
+++ b/Apps/Admin/Client/wwwroot/appsettings.Development.json
@@ -6,6 +6,6 @@
         }
     },
     "Oidc": {
-        "Authority": "https://dev.loginproxy.gov.bc.ca/auth/realms/health-gateway-gold"
+        "Authority": "https://dev.loginproxy.gov.bc.ca/auth/realms/standard"
     }
 }

--- a/Apps/Admin/Client/wwwroot/appsettings.json
+++ b/Apps/Admin/Client/wwwroot/appsettings.json
@@ -6,8 +6,8 @@
         }
     },
     "Oidc": {
-        "Authority": "https://loginproxy.gov.bc.ca/auth/realms/health-gateway-gold",
-        "ClientId": "hg-admin-blazor"
+        "Authority": "https://loginproxy.gov.bc.ca/auth/realms/standard",
+        "ClientId": "waiting-queue-4805"
     },
     "TimeZone": {
         "UnixTimeZoneId": "America/Vancouver",

--- a/Apps/Admin/Common/Models/RoomConfiguration.cs
+++ b/Apps/Admin/Common/Models/RoomConfiguration.cs
@@ -21,47 +21,47 @@ namespace BCGov.WaitingQueue.Admin.Common.Models;
 public record RoomConfiguration
 {
     /// <summary>
-    /// Gets or sets the room id.
-    /// </summary>
-    public string? Id { get; set; }
-
-    /// <summary>
     /// Gets or sets the room's name.
     /// </summary>
     public string? Name { get; set; }
 
     /// <summary>
-    /// Gets or sets the check in frequencey in seconds.
+    /// Gets or sets the check in frequency in seconds.
     /// </summary>
-    public int CheckInFrequency { get; set; }
+    public int CheckInFrequency { get; set; } = 180;
 
     /// <summary>
     /// Gets or sets the check in grace period in seconds.
     /// </summary>
-    public int CheckInGrace { get; set; }
+    public int CheckInGrace { get; set; } = 10;
 
     /// <summary>
     /// Gets or sets the room idle time to live.
     /// </summary>
-    public int RoomIdleTtl { get; set; }
+    public int RoomIdleTtl { get; set; } = 300;
 
     /// <summary>
-    /// Gets or sets the number of participants limit.
+    /// Gets or sets the maximum number of participants.
     /// </summary>
-    public int ParticipantLimit { get; set; }
+    public int ParticipantLimit { get; set; } = 800;
 
     /// <summary>
     /// Gets or sets the queue number of participant threshold.
     /// </summary>
-    public int QueueThreshold { get; set; }
+    public int QueueThreshold { get; set; } = 600;
 
     /// <summary>
     /// Gets or sets the queue maximum size.
     /// </summary>
-    public int QueueMaxSize { get; set; }
+    public int QueueMaxSize { get; set; } = 500;
 
     /// <summary>
     /// Gets or sets the maximum of remove expired maximum?.
     /// </summary>
-    public int RemoveExpiredMax { get; set; }
+    public int RemoveExpiredMax { get; set; } = 250;
+
+    /// <summary>
+    /// Gets or sets the last updated timestamp in UTC Epoch format.
+    /// </summary>
+    public long LastUpdated { get; set; }
 }

--- a/Apps/Admin/Server/AspNetConfiguration/Modules/HttpWeb.cs
+++ b/Apps/Admin/Server/AspNetConfiguration/Modules/HttpWeb.cs
@@ -116,7 +116,7 @@ namespace BCGov.WaitingQueue.Admin.Server.AspNetConfiguration.Modules
                 {
                     context.Response.Headers.Add("X-Content-Type-Options", "nosniff");
                     context.Response.Headers.Add("X-Xss-Protection", "1; mode=block");
-                    await next().ConfigureAwait(true);
+                    await next();
                 });
 
             // Enable Cache control and set defaults
@@ -188,7 +188,7 @@ namespace BCGov.WaitingQueue.Admin.Server.AspNetConfiguration.Modules
                         async (context, next) =>
                         {
                             context.Request.PathBase = basePath;
-                            await next.Invoke().ConfigureAwait(true);
+                            await next.Invoke();
                         });
                     app.UsePathBase(basePath);
                 }
@@ -224,7 +224,7 @@ namespace BCGov.WaitingQueue.Admin.Server.AspNetConfiguration.Modules
                 async (context, next) =>
                 {
                     context.Response.Headers.Add("Content-Security-Policy", csp);
-                    await next().ConfigureAwait(true);
+                    await next();
                 });
         }
 
@@ -242,7 +242,7 @@ namespace BCGov.WaitingQueue.Admin.Server.AspNetConfiguration.Modules
                     async (context, next) =>
                     {
                         context.Response.Headers.Add("Permissions-Policy", policyValue);
-                        await next().ConfigureAwait(true);
+                        await next();
                     });
             }
         }
@@ -268,7 +268,7 @@ namespace BCGov.WaitingQueue.Admin.Server.AspNetConfiguration.Modules
                             MustRevalidate = true,
                         };
                     context.Response.Headers[HeaderNames.Pragma] = new[] { "no-cache" };
-                    await next().ConfigureAwait(true);
+                    await next();
                 });
         }
     }

--- a/Apps/Admin/Server/Controllers/ConfigurationController.cs
+++ b/Apps/Admin/Server/Controllers/ConfigurationController.cs
@@ -31,7 +31,7 @@ namespace BCGov.WaitingQueue.Admin.Server.Controllers
     public class ConfigurationController : Controller
     {
         /// <summary>
-        /// Returns the external Health Gateway configuration.
+        /// Returns the external Waiting Queue configuration.
         /// </summary>
         /// <param name="configurationService">The injected configuration provider.</param>
         /// <returns>The Health Gateway Configuration.</returns>

--- a/Apps/Admin/Server/Program.cs
+++ b/Apps/Admin/Server/Program.cs
@@ -78,7 +78,7 @@ namespace BCGov.WaitingQueue.Admin.Server
             app.MapControllers();
             app.MapFallbackToFile("index.html");
 
-            await app.RunAsync().ConfigureAwait(true);
+            await app.RunAsync();
         }
 
         private static void AddModules(IServiceCollection services, IConfiguration configuration, ILogger logger, IWebHostEnvironment environment)

--- a/Apps/Admin/Server/appsettings.Development.json
+++ b/Apps/Admin/Server/appsettings.Development.json
@@ -5,12 +5,8 @@
         }
     },
     "OpenIdConnect": {
-        "Authority": "https://dev.loginproxy.gov.bc.ca/auth/realms/health-gateway-gold",
-        "RequireHttpsMetadata": "false",
-        "Callbacks": {
-            "Logon": "http://localhost:5027/",
-            "Logout": "http://localhost:5027/authentication/login"
-        }
+        "Authority": "https://dev.loginproxy.gov.bc.ca/auth/realms/standard",
+        "RequireHttpsMetadata": "false"
     },
     "ContentSecurityPolicy": {
         "ConnectSource": "'self' file: data: blob: filesystem: https: http: ws:",

--- a/Apps/Admin/Server/appsettings.json
+++ b/Apps/Admin/Server/appsettings.json
@@ -19,18 +19,14 @@
         }
     },
     "OpenIdConnect": {
-        "Authority": "https://loginproxy.gov.bc.ca/auth/realms/health-gateway-gold",
-        "ClientId": "hg-admin",
-        "Audience": "hg-admin",
+        "Authority": "https://loginproxy.gov.bc.ca/auth/realms/standard",
+        "ClientId": "waiting-queue-4805",
+        "Audience": "waiting-queue-4805",
         "SaveTokens": "true",
         "GetClaimsFromUserInfoEndpoint": "true",
         "SignedOutRedirectUri": "/signoff",
         "ResponseType": "code",
-        "Scope": "openid profile email",
-        "Callbacks": {
-            "Logon": "https://admin.healthgateway.gov.bc.ca/",
-            "Logout": "https://admin.healthgateway.gov.bc.ca/authentication/login"
-        }
+        "Scope": "openid profile email"
     },
     "SwaggerSettings": {
         "RoutePrefix": "swagger",

--- a/Apps/TicketManagement/Issuers/KeycloakIssuer.cs
+++ b/Apps/TicketManagement/Issuers/KeycloakIssuer.cs
@@ -54,7 +54,7 @@ namespace BCGov.WaitingQueue.TicketManagement.Issuers
             Stopwatch stopwatch = new();
             stopwatch.Start();
             TokenRequest tokenRequest = this.configuration.RoomConfiguration[room];
-            TokenResponse tokenResponse = await this.keycloakApi.AuthenticateAsync(tokenRequest).ConfigureAwait(true);
+            TokenResponse tokenResponse = await this.keycloakApi.AuthenticateAsync(tokenRequest);
             JwtSecurityTokenHandler handler = new();
             JwtSecurityToken token = handler.ReadJwtToken(tokenResponse.AccessToken);
             DateTimeOffset ticketExpiry = token.ValidTo;

--- a/Apps/TicketManagement/Services/IRoomService.cs
+++ b/Apps/TicketManagement/Services/IRoomService.cs
@@ -35,21 +35,20 @@ namespace BCGov.WaitingQueue.TicketManagement.Services
         /// Creates or Updates the room configuration in the datastore.
         /// </summary>
         /// <param name="roomConfig">The room configuration to create or update.</param>
-        /// <param name="create">If true attempts to create the configuration instead of updating.</param>
         /// <returns>A boolean indicating if the operation was successful and the configuration.</returns>
-        Task<(bool Committed, RoomConfiguration RoomConfig)> WriteConfigurationAsync(RoomConfiguration roomConfig, bool create = false);
+        Task<(bool Committed, RoomConfiguration RoomConfig)> WriteConfigurationAsync(RoomConfiguration roomConfig);
 
         /// <summary>
         /// Returns an optimistic indicator for the existence of the room.
         /// </summary>
         /// <param name="room">The room to check for the existence of.</param>
-        /// <returns>An indicator</returns>
+        /// <returns>A boolean representing if the room exists or not.</returns>
         Task<bool> RoomExists(string room);
 
         /// <summary>
         /// Lists all the rooms in the datastore.
         /// </summary>
         /// <returns>A list of strings identifying each room.</returns>
-        Task<IEnumerable<string>> GetRoomsAsync();
+        Task<Dictionary<string, RoomConfiguration>> GetRoomsAsync();
     }
 }

--- a/Apps/WaitingQueueWeb/Configuration/ServiceConfiguration.cs
+++ b/Apps/WaitingQueueWeb/Configuration/ServiceConfiguration.cs
@@ -43,6 +43,7 @@ namespace BCGov.WaitingQueue.Configuration
         public static void ConfigureServices(IServiceCollection services, IConfiguration configuration)
         {
             services.AddTransient<ITicketService, RedisTicketService>();
+            services.AddTransient<IRoomService, RedisRoomService>();
             services.AddTransient<IDateTimeDelegate, DateTimeDelegate>();
             services.AddTransient<IWebTicketDelegate, WebTicketDelegate>();
 

--- a/Apps/WaitingQueueWeb/Controllers/TicketController.cs
+++ b/Apps/WaitingQueueWeb/Controllers/TicketController.cs
@@ -88,7 +88,7 @@ namespace BCGov.WaitingQueue.Controllers
         [ProducesResponseType(StatusCodes.Status503ServiceUnavailable)]
         public async Task<ActionResult<Ticket>> GetTicket(string room, Guid ticketId, string nonce)
         {
-            return await this.ticketDelegate.GetTicket(room, ticketId, nonce).ConfigureAwait(true);
+            return await this.ticketDelegate.GetTicket(room, ticketId, nonce);
         }
 
         /// <summary>
@@ -105,7 +105,7 @@ namespace BCGov.WaitingQueue.Controllers
         [ProducesResponseType(StatusCodes.Status503ServiceUnavailable)]
         public async Task<ActionResult<Ticket>> CreateTicket([FromQuery]string room)
         {
-            return await this.ticketDelegate.CreateTicket(room).ConfigureAwait(true);
+            return await this.ticketDelegate.CreateTicket(room);
         }
 
         /// <summary>
@@ -125,7 +125,7 @@ namespace BCGov.WaitingQueue.Controllers
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> CheckIn(TicketRequest ticketRequest)
         {
-            return this.Ok(await this.ticketDelegate.CheckInAsync(ticketRequest).ConfigureAwait(true));
+            return this.Ok(await this.ticketDelegate.CheckInAsync(ticketRequest));
         }
 
         /// <summary>
@@ -141,7 +141,7 @@ namespace BCGov.WaitingQueue.Controllers
         [HttpDelete]
         public async Task RemoveTicket(TicketRequest ticketRequest)
         {
-            await this.ticketDelegate.RemoveTicketAsync(ticketRequest).ConfigureAwait(true);
+            await this.ticketDelegate.RemoveTicketAsync(ticketRequest);
         }
     }
 }

--- a/Apps/WaitingQueueWeb/appsettings.json
+++ b/Apps/WaitingQueueWeb/appsettings.json
@@ -8,26 +8,6 @@
     "AllowOrigins": "*",
     "AllowedHosts": "*",
     "RedisConnection": "SECRET",
-    "RoomHealthGateway": {
-        "Name": "HealthGateway",
-        "CheckInFrequency": 120,
-        "CheckInGrace": 30,
-        "RoomIdleTtl": 300,
-        "ParticipantLimit": 10,
-        "QueueThreshold": 5,
-        "QueueMaxSize": 10,
-        "RemoveExpiredMax": 250
-    },
-    "RoomARD": {
-        "Name": "ARD",
-        "CheckInFrequency": 120,
-        "CheckInGrace": 100,
-        "RoomIdleTtl": 300,
-        "ParticipantLimit": 800,
-        "QueueThreshold": 250,
-        "QueueMaxSize": 500,
-        "RemoveExpiredMax": 250
-    },
     "TokenIssuer": "InternalIssuer",
     "KeycloakIssuer": {
         "BaseUri": "https://loginproxy.gov.bc.ca/auth/realms/health-gateway-gold",

--- a/Apps/WebCommon/Delegates/WebTicketDelegate.cs
+++ b/Apps/WebCommon/Delegates/WebTicketDelegate.cs
@@ -51,25 +51,25 @@ namespace BCGov.WebCommon.Delegates
                 Id = ticketId,
                 Nonce = nonce,
             };
-            return await this.ticketService.GetTicketAsync(ticketRequest).ConfigureAwait(true);
+            return await this.ticketService.GetTicketAsync(ticketRequest);
         }
 
         /// <inheritdoc />
         public async Task<Ticket> CreateTicket(string room)
         {
-            return await this.ticketService.RequestTicketAsync(room).ConfigureAwait(true);
+            return await this.ticketService.RequestTicketAsync(room);
         }
 
         /// <inheritdoc />
         public async Task<Ticket> CheckInAsync(TicketRequest ticketRequest)
         {
-            return await this.ticketService.CheckInAsync(ticketRequest).ConfigureAwait(true);
+            return await this.ticketService.CheckInAsync(ticketRequest);
         }
 
         /// <inheritdoc />
         public async Task RemoveTicketAsync(TicketRequest ticketRequest)
         {
-            await Task.CompletedTask.ConfigureAwait(true);
+            await Task.CompletedTask;
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
Wired UI to hit Room Config API
Updated Room Config API based on UI
Enabled Waiting Queue standard realm auth and roles
Set default values for room configuration
Updated editor config to set ConfigureAwait warning to none and removed from code

One item to note is that the config lookup adds about 30ms to the transaction time which doubles the average transaction time.  We may want to consider a short lived memory cache in the future.