### PR TITLE
Add Room based access controls

### DIFF
--- a/Apps/Admin/Client/Api/IRoomApi.cs
+++ b/Apps/Admin/Client/Api/IRoomApi.cs
@@ -35,10 +35,11 @@ namespace BCGov.WaitingQueue.Admin.Client.Api
         /// <summary>
         /// Creates or updates the room configuration.
         /// </summary>
+        /// <param name="room">The room name to create or update.</param>
         /// <param name="roomConfig">The room to create or update.</param>
         /// <returns>The newly created or updated room configuration.</returns>
-        [Put("/")]
-        Task<RoomConfiguration> UpsertConfiguration(RoomConfiguration roomConfig);
+        [Put("/{room}")]
+        Task<RoomConfiguration> UpsertConfiguration(string room, RoomConfiguration roomConfig);
 
         /// <summary>
         /// Gets a room's statistics.

--- a/Apps/Admin/Client/Pages/RoomConfigPage.razor.cs
+++ b/Apps/Admin/Client/Pages/RoomConfigPage.razor.cs
@@ -99,7 +99,7 @@ public partial class RoomConfigPage : ComponentBase
             this.ErrorMessage = null;
             try
             {
-                this.Rooms[item.Name] = await this.RoomApi.UpsertConfiguration(item);
+                this.Rooms[item.Name] = await this.RoomApi.UpsertConfiguration(item.Name, item);
             }
             catch (Exception e) when (e is ApiException or HttpRequestException)
             {

--- a/Apps/Admin/Server/Authorization/Roles.cs
+++ b/Apps/Admin/Server/Authorization/Roles.cs
@@ -1,0 +1,33 @@
+// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace BCGov.WaitingQueue.Admin.Server.Authorization
+{
+    /// <summary>
+    /// The roles available to the application.
+    /// </summary>
+    public static class Roles
+    {
+        /// <summary>
+        /// A user allowed to administrate the rooms.
+        /// </summary>
+        public const string Admin = "AdminUser";
+
+        /// <summary>
+        /// A user allowed to view the statistics page.
+        /// </summary>
+        public const string Stats = "StatsUser";
+    }
+}

--- a/Apps/Admin/Server/Authorization/RoomAccessHandler.cs
+++ b/Apps/Admin/Server/Authorization/RoomAccessHandler.cs
@@ -1,0 +1,60 @@
+// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace BCGov.WaitingQueue.Admin.Server.Authorization
+{
+    using System.Linq;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.Extensions.Logging;
+
+    /// <summary>
+    /// Assets the user has access to the room.
+    /// </summary>
+    public class RoomAccessHandler : IAuthorizationHandler
+    {
+        private const string RouteResourceIdentifier = "room";
+        private readonly IHttpContextAccessor httpContextAccessor;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RoomAccessHandler"/> class.
+        /// </summary>
+        /// <param name="httpContextAccessor">The injected HttpContext accessor.</param>
+        public RoomAccessHandler(IHttpContextAccessor httpContextAccessor)
+        {
+            this.httpContextAccessor = httpContextAccessor;
+        }
+
+        /// <summary>
+        /// .
+        /// </summary>
+        /// <param name="context">The authorization information.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        public Task HandleAsync(AuthorizationHandlerContext context)
+        {
+            foreach (RoomAccessRequirement requirement in context.PendingRequirements.OfType<RoomAccessRequirement>())
+            {
+                string? room = this.httpContextAccessor.HttpContext?.Request.RouteValues[RouteResourceIdentifier] as string;
+                if (room != null && requirement.SupportsRoomAccess(this.httpContextAccessor.HttpContext, room))
+                {
+                    context.Succeed(requirement);
+                }
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/Apps/Admin/Server/Authorization/RoomAccessRequirement.cs
+++ b/Apps/Admin/Server/Authorization/RoomAccessRequirement.cs
@@ -1,0 +1,66 @@
+// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace BCGov.WaitingQueue.Admin.Server.Authorization
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Globalization;
+    using System.Linq;
+    using System.Security.Claims;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Http;
+
+    /// <summary>
+    /// Asserts authorization to access one or more rooms.
+    /// </summary>
+    public class RoomAccessRequirement : IAuthorizationRequirement
+    {
+        /// <summary>
+        /// Gets the rooms the user is authorized to access.
+        /// </summary>
+        /// <param name="context">The supplied HttpContext.</param>
+        /// <returns>An Enumerable of rooms the user has access to.</returns>
+        public static IEnumerable<string> GetUserRooms(HttpContext? context)
+        {
+            string prefix = "room::";
+            IEnumerable<string>? rooms = context?.User.FindAll(ClaimTypes.Role).Select(c => c.Value)
+                .Where(role => role.StartsWith(prefix, true, CultureInfo.InvariantCulture))
+                .Select(role => role[prefix.Length..]);
+            return rooms ?? Array.Empty<string>();
+        }
+
+        /// <summary>
+        /// Gets the rooms the user is authorized to access.
+        /// </summary>
+        /// <param name="contextAccessor">The supplied HttpContextAccessor.</param>
+        /// <returns>An Enumerable of rooms the user has access to.</returns>
+        public static IEnumerable<string> GetUserRooms(IHttpContextAccessor contextAccessor)
+        {
+            return GetUserRooms(contextAccessor.HttpContext);
+        }
+
+        /// <summary>
+        /// Returns true if the user can interact with the room.
+        /// </summary>
+        /// <param name="context">The Http context.</param>
+        /// <param name="room">The room to validate.</param>
+        /// <returns>A bool indicating if the user can interact with this room.</returns>
+        public bool SupportsRoomAccess(HttpContext? context, string room)
+        {
+            return GetUserRooms(context).Contains(room, StringComparer.InvariantCultureIgnoreCase);
+        }
+    }
+}

--- a/Apps/Admin/Server/Authorization/RoomPolicy.cs
+++ b/Apps/Admin/Server/Authorization/RoomPolicy.cs
@@ -1,0 +1,28 @@
+// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace BCGov.WaitingQueue.Admin.Server.Authorization
+{
+    /// <summary>
+    /// The available policies for rooms.
+    /// </summary>
+    public static class RoomPolicy
+    {
+        /// <summary>
+        /// Provides read and write access to the room.
+        /// </summary>
+        public const string RoomAccess = "RoomAccess";
+    }
+}

--- a/Apps/Admin/Server/Controllers/RoomController.cs
+++ b/Apps/Admin/Server/Controllers/RoomController.cs
@@ -15,11 +15,10 @@
 //-------------------------------------------------------------------------
 namespace BCGov.WaitingQueue.Admin.Server.Controllers
 {
-    using System.Collections.Concurrent;
     using System.Collections.Generic;
     using System.Linq;
-    using System.Threading;
     using System.Threading.Tasks;
+    using BCGov.WaitingQueue.Admin.Server.Authorization;
     using BCGov.WaitingQueue.TicketManagement.Models;
     using BCGov.WaitingQueue.TicketManagement.Models.Statistics;
     using BCGov.WaitingQueue.TicketManagement.Services;
@@ -32,7 +31,7 @@ namespace BCGov.WaitingQueue.Admin.Server.Controllers
     /// </summary>
     [ApiController]
     [ApiVersion("1.0")]
-    [Authorize(Roles = "AdminUser")]
+    [Authorize]
     [Route("api/[controller]")]
     [Produces("application/json")]
     public class RoomController : Controller
@@ -52,14 +51,32 @@ namespace BCGov.WaitingQueue.Admin.Server.Controllers
         }
 
         /// <summary>
-        /// Returns a dictionary of rooms along with their associated configuration.
+        /// Returns a dictionary of rooms along with their associated configuration that the user can interact with.
         /// </summary>
         /// <returns>The key/value pairs of room configurations.</returns>
+        [Authorize(Roles = Roles.Admin)]
         [HttpGet]
         [ProducesResponseType(typeof(IEnumerable<RoomConfiguration>), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
         public async Task<IDictionary<string, RoomConfiguration>> Index()
         {
-            return await this.roomService.GetRoomsAsync();
+            return await this.roomService.GetRoomsAsync(RoomAccessRequirement.GetUserRooms(this.HttpContext));
+        }
+
+        /// <summary>
+        /// Get a room's statistics information.
+        /// </summary>
+        /// <returns>The room statistics information.</returns>
+        [Authorize(Roles = $"{Roles.Admin}, {Roles.Stats}")]
+        [HttpGet]
+        [Route("stats")]
+        [ProducesResponseType(typeof(IEnumerable<RoomConfiguration>), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        public async Task<ActionResult<IEnumerable<Common.Models.RoomStatistics>>> GetRoomStatistics()
+        {
+            Dictionary<string, RoomConfiguration> rooms = await this.roomService.GetRoomsAsync(RoomAccessRequirement.GetUserRooms(this.HttpContext));
+            RoomStatistics[] statistics = await Task.WhenAll(rooms.Select(r => this.ticketService.QueryRoomStatistics(r.Key)));
+            return this.Ok(statistics.Select(s => new Common.Models.RoomStatistics(s.Room, s.Counters.Select(c => new Common.Models.Counter(c.Name, c.Description, c.Value)))));
         }
 
         /// <summary>
@@ -67,9 +84,11 @@ namespace BCGov.WaitingQueue.Admin.Server.Controllers
         /// </summary>
         /// <param name="room">The room to lookup the configuration for.</param>
         /// <returns>The Health Gateway Configuration.</returns>
+        [Authorize(Policy = RoomPolicy.RoomAccess)]
         [HttpGet]
         [Route("{room}")]
         [ProducesResponseType(typeof(RoomConfiguration), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> GetConfig(string room)
         {
@@ -87,9 +106,11 @@ namespace BCGov.WaitingQueue.Admin.Server.Controllers
         /// </summary>
         /// <param name="room">The room to query existence.</param>
         /// <returns>A boolean indicating the existence.</returns>
+        [Authorize(Policy = RoomPolicy.RoomAccess)]
         [HttpGet]
         [Route("{room}/exists")]
         [ProducesResponseType(typeof(bool), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
         public async Task<bool> Exists(string room)
         {
             bool exists = await this.roomService.RoomExists(room);
@@ -99,13 +120,18 @@ namespace BCGov.WaitingQueue.Admin.Server.Controllers
         /// <summary>
         /// Creates or updates the room configuration.
         /// </summary>
+        /// <param name="room">The room to create or update.</param>
         /// <param name="roomConfig">The new room configuration.</param>
         /// <returns>The newly updated/created room configuration.</returns>
+        [Authorize(Policy = RoomPolicy.RoomAccess)]
         [HttpPut]
+        [Route("{room}")]
         [ProducesResponseType(typeof(RoomConfiguration), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
         [ProducesResponseType(StatusCodes.Status409Conflict)]
-        public async Task<IActionResult> UpsertRoom(RoomConfiguration roomConfig)
+        public async Task<IActionResult> UpsertRoom(string room, RoomConfiguration roomConfig)
         {
+            roomConfig.Name = room;
             (bool committed, RoomConfiguration config) = await this.roomService.WriteConfigurationAsync(roomConfig);
             if (committed)
             {
@@ -113,20 +139,6 @@ namespace BCGov.WaitingQueue.Admin.Server.Controllers
             }
 
             return new ConflictResult();
-        }
-
-        /// <summary>
-        /// Get a room's statistics information.
-        /// </summary>
-        /// <returns>The room statistics information.</returns>
-        [HttpGet]
-        [Route("stats")]
-        public async Task<ActionResult<IEnumerable<Common.Models.RoomStatistics>>> GetRoomStatistics()
-        {
-            Dictionary<string, RoomConfiguration>? rooms = await this.roomService.GetRoomsAsync();
-
-            RoomStatistics[] statistics = await Task.WhenAll(rooms.Select(r => this.ticketService.QueryRoomStatistics(r.Key)));
-            return this.Ok(statistics.Select(s => new Common.Models.RoomStatistics(s.Room, s.Counters.Select(c => new Common.Models.Counter(c.Name, c.Description, c.Value)))));
         }
     }
 }

--- a/Apps/Admin/Server/Controllers/RoomController.cs
+++ b/Apps/Admin/Server/Controllers/RoomController.cs
@@ -57,7 +57,7 @@ namespace BCGov.WaitingQueue.Admin.Server.Controllers
         [Authorize(Roles = Roles.Admin)]
         [HttpGet]
         [ProducesResponseType(typeof(IEnumerable<RoomConfiguration>), StatusCodes.Status200OK)]
-        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
         public async Task<IDictionary<string, RoomConfiguration>> Index()
         {
             return await this.roomService.GetRoomsAsync(RoomAccessRequirement.GetUserRooms(this.HttpContext));
@@ -71,7 +71,7 @@ namespace BCGov.WaitingQueue.Admin.Server.Controllers
         [HttpGet]
         [Route("stats")]
         [ProducesResponseType(typeof(IEnumerable<RoomConfiguration>), StatusCodes.Status200OK)]
-        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
         public async Task<ActionResult<IEnumerable<Common.Models.RoomStatistics>>> GetRoomStatistics()
         {
             Dictionary<string, RoomConfiguration> rooms = await this.roomService.GetRoomsAsync(RoomAccessRequirement.GetUserRooms(this.HttpContext));
@@ -88,7 +88,7 @@ namespace BCGov.WaitingQueue.Admin.Server.Controllers
         [HttpGet]
         [Route("{room}")]
         [ProducesResponseType(typeof(RoomConfiguration), StatusCodes.Status200OK)]
-        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> GetConfig(string room)
         {
@@ -110,7 +110,7 @@ namespace BCGov.WaitingQueue.Admin.Server.Controllers
         [HttpGet]
         [Route("{room}/exists")]
         [ProducesResponseType(typeof(bool), StatusCodes.Status200OK)]
-        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
         public async Task<bool> Exists(string room)
         {
             bool exists = await this.roomService.RoomExists(room);
@@ -127,7 +127,7 @@ namespace BCGov.WaitingQueue.Admin.Server.Controllers
         [HttpPut]
         [Route("{room}")]
         [ProducesResponseType(typeof(RoomConfiguration), StatusCodes.Status200OK)]
-        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
         [ProducesResponseType(StatusCodes.Status409Conflict)]
         public async Task<IActionResult> UpsertRoom(string room, RoomConfiguration roomConfig)
         {

--- a/Apps/TicketManagement/Services/IRoomService.cs
+++ b/Apps/TicketManagement/Services/IRoomService.cs
@@ -46,9 +46,10 @@ namespace BCGov.WaitingQueue.TicketManagement.Services
         Task<bool> RoomExists(string room);
 
         /// <summary>
-        /// Lists all the rooms in the datastore.
+        /// Lists all the configured rooms that match the supplied rooms.
         /// </summary>
+        /// <param name="rooms">The rooms to query.</param>
         /// <returns>A list of strings identifying each room.</returns>
-        Task<Dictionary<string, RoomConfiguration>> GetRoomsAsync();
+        Task<Dictionary<string, RoomConfiguration>> GetRoomsAsync(IEnumerable<string> rooms);
     }
 }


### PR DESCRIPTION
Adds Keycloak role based security for room access.  For each room role in Keycloak you can add or edit if you're an admin or view the stats if you have the stats role.